### PR TITLE
use broctl deploy to reload bro

### DIFF
--- a/bro/README.md
+++ b/bro/README.md
@@ -85,9 +85,7 @@ redef record SSH::Info += {
 
 After ammending the bro script, don't forget to reload bro. 
 ```bash
-broctl stop
-broctl install
-broctl start
+broctl deploy
 ```
 
 ## Credits:


### PR DESCRIPTION
broctl deploy is a wrapper for check+install+restart and ensures that the configuration is valid before stopping bro and updating the configuration.