### PR TITLE
Bug: Undeclared sshka when running on Centos 7

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -7,8 +7,9 @@ HASSH is a method for creating SSH Client and Server fingerprints. This python s
 You can use [hasshGen.py](hasshGen/) to automate building docker images with different SSH clients/versions for generating HASSH fingerprints. As a demonstration we created a list ([sshClient_list](hasshGen/sshClient_list)) containing 49 different version of OpenSSH, Python’s paramiko and Dropbear SSH clients and generated a database of HASSH fingerprints in [JSON](hasshGen/hassh_fingerprints.json) and [CSV](hasshGen/hassh_fingerprints.csv) formats.
 
 ## Getting Started
-1. Install Tshark. E.g. on Debian/Ubuntu:
-    > `apt-get install tshark`
+1. Install Tshark. 
+    > `apt-get install tshark` on Debian/Ubuntu or `yum install wireshark` on Centos 7
+    
 
 2. Install Pipenv:
     > `pip3 install pipenv`

--- a/python/hassh.py
+++ b/python/hassh.py
@@ -167,7 +167,7 @@ def client_hassh(packet):
     if 'compression_algorithms_client_to_server' in packet.ssh.field_names:
         ccacts = packet.ssh.compression_algorithms_client_to_server
     # Log other kexinit fields (only in JSON)
-    clcts = clstc = ceastc = cmastc = ccastc = ""
+    clcts = clstc = ceastc = cmastc = ccastc = cshka = ""
     if 'languages_client_to_server' in packet.ssh.field_names:
         clcts = packet.ssh.languages_client_to_server
     if 'languages_server_to_client' in packet.ssh.field_names:
@@ -228,7 +228,7 @@ def server_hassh(packet):
     if 'compression_algorithms_server_to_client' in packet.ssh.field_names:
         scastc = packet.ssh.compression_algorithms_server_to_client
     # Log other kexinit fields (only in JSON)
-    slcts = slstc = seacts = smacts = scacts = ""
+    slcts = slstc = seacts = smacts = scacts = sshka = ""
     if 'languages_client_to_server' in packet.ssh.field_names:
         slcts = packet.ssh.languages_client_to_server
     if 'languages_server_to_client' in packet.ssh.field_names:


### PR DESCRIPTION
Executing the Python code on Centos 7 with Python 3.7.2  resulted in the following crash:

```

Traceback (most recent call last):
  File "hassh.py", line 428, in <module>
    main()
  File "hassh.py", line 422, in main
    pout=args.print_output)
  File "hassh.py", line 100, in process_packet
    record = server_hassh(packet)
  File "hassh.py", line 265, in server_hassh
    "sshka": sshka}
UnboundLocalError: local variable 'sshka' referenced before assignment

```

This appears to be due to the field being empty in the packet. 

Attached fix explicitly initialises the relevant pair of variables. It also includes the relevant command to install tshark on Centos 7.