### PR TITLE
Change to Zeek naming

### DIFF
--- a/bro/__load__.bro
+++ b/bro/__load__.bro
@@ -1,1 +1,0 @@
-@load ./hassh.bro

--- a/zeek/README.md
+++ b/zeek/README.md
@@ -1,28 +1,28 @@
-# hassh.bro
+# hassh.zeek
 [![License: BSD 3-Clause License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 
 ## Features
-**hassh.bro** by default will add these fields to your bro ssh.log file 
+**hassh.zeek** by default will add these fields to your Zeek ssh.log file 
 - hasshVersion
 - hassh, hasshAlgorithms 
 - hasshServer, hasshServerAlgorithms
 - cshka (Client Host Key Algorithms), sshka (Server Host Key Algorithms)  
-- The script has been tested on Bro 2.5, 2.5.1, 2.5.5, 2.6.0, 2.6.1 and 2.6.3 
-- Note that bro versions < v2.6.0 had a bug which reversed the Client/server flag , see https://github.com/zeek/zeek/pull/191. The current version of the hassh.bro script does version checking to deal with these version issues. Failure to update bro and not the hassh.bro script will result in the Server and Client packets being processed incorrectly, in effect swapping around hassh with hassServer.  
+- The script has been tested on Bro 2.5, 2.5.1, 2.5.5, 2.6.0, 2.6.1, 2.6.3 and 3.0.0
+- Note that Zeek (formerly bro) versions < v2.6.0 had a bug which reversed the Client/server flag , see https://github.com/zeek/zeek/pull/191. The current version of the hassh.zeek script does version checking to deal with these version issues. Failure to update Zeek and not the hassh.zeek script will result in the Server and Client packets being processed incorrectly, in effect swapping around hassh with hassServer.  
 
 ## Installation
-Place hassh.bro in bro/share/bro/site/hassh and add this line to your local.bro script:
+Place hassh.zeek in zeek/share/zeek/site/hassh and add this line to your local.zeek script:
 ```bash
 @load ./hassh
 ```
-If running Bro >=2.5 or a Bro product like Corelight, install by using the Bro Package Manager with this command:
+If running Zeek >=2.5 or a Zeek product like Corelight, install by using the Zeek Package Manager with this command:
 ```bash 
-bro-pkg install hassh
+zkg install hassh
 ```
 
 
 ## Configuration
-**hassh.bro** by default will add these fields to your bro ssh.log file: ```hasshVersion, hassh, hasshAlgorithms, hasshServer and hasshServerAlgorithms, cshka, sshka.``` If you don't want some of these fields to be logged, simply comment those field lines out in each of the locations within hassh.bro as shown in the code blocks below.
+**hassh.zeek** by default will add these fields to your Zeek ssh.log file: ```hasshVersion, hassh, hasshAlgorithms, hasshServer and hasshServerAlgorithms, cshka, sshka.``` If you don't want some of these fields to be logged, simply comment those field lines out in each of the locations within hassh.zeek as shown in the code blocks below.
 ```bash
 redef record SSH::Info += {
     hasshVersion:  string  &log &optional;
@@ -83,11 +83,11 @@ redef record SSH::Info += {
     }
 ```
 
-After ammending the bro script, don't forget to reload bro. 
+After ammending the Zeek script, don't forget to reload Zeek. 
 ```bash
-broctl stop
-broctl install
-broctl start
+zeekctl stop
+zeekctl install
+zeekctl start
 ```
 
 ## Credits:

--- a/zeek/README.md
+++ b/zeek/README.md
@@ -7,7 +7,7 @@
 - hassh, hasshAlgorithms 
 - hasshServer, hasshServerAlgorithms
 - cshka (Client Host Key Algorithms), sshka (Server Host Key Algorithms)  
-- The script has been tested on Bro 2.5, 2.5.1, 2.5.5, 2.6.0, 2.6.1, 2.6.3 and 3.0.0
+- The script has been tested on Bro 2.5, 2.5.1, 2.5.5, 2.6.0, 2.6.1, 2.6.3, 3.0.0 and 3.1.2
 - Note that Zeek (formerly bro) versions < v2.6.0 had a bug which reversed the Client/server flag , see https://github.com/zeek/zeek/pull/191. The current version of the hassh.zeek script does version checking to deal with these version issues. Failure to update Zeek and not the hassh.zeek script will result in the Server and Client packets being processed incorrectly, in effect swapping around hassh with hassServer.  
 
 ## Installation

--- a/zeek/__load__.zeek
+++ b/zeek/__load__.zeek
@@ -1,0 +1,1 @@
+@load ./hassh.zeek

--- a/zeek/hassh.zeek
+++ b/zeek/hassh.zeek
@@ -5,7 +5,7 @@
 # Authors: Ben Reardon (breardon@salesforce.com, @benreardon)        #
 #        : Jeff Atkinson (jatkinson@salesforce.com)                  #
 #        : John Althouse (jalthouse@salesforce.com)                  #
-# Description:  This bro script appends hassh data to ssh.log        #
+# Description:  This Zeek script appends hassh data to ssh.log       #
 #               by enumerating the SSH_MSG_KEXINIT packets sent      #
 #               as clear text between the client and server as part  # 
 #               of the negotiation of an SSH connection.             #
@@ -107,7 +107,7 @@ event ssh_capabilities(c: connection, cookie: string, capabilities: SSH::Capabil
     if ( !c?$ssh ) {return;}
     c$hassh = HASSHStorage();
     
-    # Prior to 2.6.0 bro has a bug which it reverses the Client/server flag.
+    # Prior to 2.6.0 Zeek has a bug which it reverses the Client/server flag.
     # See https://github.com/zeek/zeek/pull/191
     # The "if" statements here do a version check to account for this bug in versions older than 2.6.0
     

--- a/zkg.meta
+++ b/zkg.meta
@@ -1,5 +1,5 @@
 [package]
-script_dir = bro
+script_dir = zeek
 description = HASSH is used to identify specific Client and Server SSH implementations. The fingerprints can be stored, searched and shared in the form of an MD5 fingerprint. This package logs components to ssh.log
-tags = bro plugin, ssh, fingerprint, logging
+tags = zeek plugin, ssh, fingerprint, logging
 version = 1.0


### PR DESCRIPTION
Similar in spirit to what was done for JA3 via https://github.com/salesforce/ja3/pull/45, these changes attempt to bring HASSH to current Zeek standards by de-bro-ing them. I've tested out the changes by installing with Zeek Package Manager on "stock" installs of Zeek v3.0.0 and v3.1.2, as well as manually installing atop our own Zeek fork at https://github.com/brimsec/zeek which was my original intended use case.