### PR TITLE
Updated python packages to address docker container failing to build

### DIFF
--- a/python/docker/Dockerfile
+++ b/python/docker/Dockerfile
@@ -19,7 +19,7 @@ FROM alpine:latest
 MAINTAINER Adel Karimi (@0x4d31)
 ENV DEBIAN_FRONTEND noninteractive
 RUN apk --no-cache add python3 gcc \
-    py-lxml tshark \
+    py3-pip py3-lxml tshark \
     && pip3 install pyshark
 WORKDIR /opt/hassh
 ADD https://raw.githubusercontent.com/salesforce/hassh/master/python/hassh.py .


### PR DESCRIPTION
Added:
py3-pip

Changed:
py-lxml -> py3-lxml

When you attempt to build [Dockerfile](https://github.com/salesforce/hassh/blob/cfa2315257eaa972e86f7fcd694712e0d32762ff/python/docker/Dockerfile), you get an error due to package name changes in alpine:

```shell
docker build .
[+] Building 1.2s (6/8)                                                                                                                   
 => [internal] load build definition from Dockerfile                                                                                 0.0s
 => => transferring dockerfile: 1.74kB                                                                                               0.0s
 => [internal] load .dockerignore                                                                                                    0.0s
 => => transferring context: 2B                                                                                                      0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                     0.0s
 => CACHED [1/4] FROM docker.io/library/alpine:latest                                                                                0.0s
 => CACHED https://raw.githubusercontent.com/salesforce/hassh/master/python/hassh.py                                                 0.0s
 => ERROR [2/4] RUN apk --no-cache add python3 gcc     py-lxml tshark     && pip3 install pyshark                                    1.1s
------                                                                                                                                    
 > [2/4] RUN apk --no-cache add python3 gcc     py-lxml tshark     && pip3 install pyshark:                                               
#5 0.259 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz                                                    
#5 0.758 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
#5 1.012 ERROR: unable to select packages:
#5 1.064   py-lxml (no such package):
#5 1.064     required by: world[py-lxml]
------
executor failed running [/bin/sh -c apk --no-cache add python3 gcc     py-lxml tshark     && pip3 install pyshark]: exit code: 1
```

This updates the packages and allows the Dockerfile to build and run properly